### PR TITLE
Fix missing site name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,9 @@ author:
   name:       'Kin Lane'
   email:      'info@apievangelist.com'
 
+site:
+  name: API Commons
+
 permalink: /:categories/:year/:month/:day/:title/
 paginate:           25
 


### PR DESCRIPTION
Add site name to config. Should now display site name prefix for all page titles.