### PR TITLE
Rate Limits is machine-readable — wire in the schema repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ both humans and agents can consume it. Each lives in its own repo under
 - [**use-cases**](https://github.com/api-commons/use-cases) — the use cases an API serves.
 - [**vocabulary**](https://github.com/api-commons/vocabulary) — shared words and definitions for API operations.
 - [**plans**](https://github.com/api-commons/plans) — access plans, tiers, and pricing.
+- [**rate-limits**](https://github.com/api-commons/rate-limits) — the quotas an API enforces, machine-readably.
 - [**change-log**](https://github.com/api-commons/change-log) — publish an API's changelog, machine-readably.
 - [**road-map**](https://github.com/api-commons/road-map) — publish an API's roadmap, machine-readably.
 - [**interface-license**](https://github.com/api-commons/interface-license) — apply an open license to your API's interface (its surface, not its implementation).

--- a/_common/rate-limits.md
+++ b/_common/rate-limits.md
@@ -3,7 +3,7 @@ name: Rate Limits
 description: All APIs should possess rate limits that govern the amount of any digital resource or capability a consumer be able to access, with well-communicated, consistent, and enforced rate limits. Rate limits are what give API producers control over their digital resources, and are a fundamental aspect of how any type of APIs is publicly made available.
 image: /images/rate-limits.png
 url: '#'
-machineReadable: false
+machineReadable: true
 source: commons
 tags:
   - Rate Limits
@@ -14,10 +14,22 @@ aliases:
   - Quotas
   - Usage Limits
 yaml_example: |
-  - type: RateLimits
+  - name: Rate Limits
+    type: RateLimits
     url: https://developers.example.com/rate-limits
+    source_date: '2026-08-17'
+    data:
+      - name: Platform requests
+        type: Platform
+        limit: 10000
+        metric: request
+        timeframe: hour
+        description: Requests per hour across the whole API for a single account.
 
 standards:
+  - name: API Commons Rate Limits schema
+    url: https://github.com/api-commons/rate-limits
+    kind: API Commons (Apache-2.0)
   - name: RateLimit header fields for HTTP (draft-ietf-httpapi-ratelimit-headers)
     url: https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/
     kind: IETF
@@ -106,6 +118,10 @@ risk:
   security_implications: Without enforced rate limits, APIs are vulnerable to credential stuffing, scraping, denial-of-wallet (for metered backends), and DoS. Apply per-key, per-IP, and per-tenant limits; surface quota state via standard headers; degrade gracefully with 429 + Retry-After rather than dropping connections.
 
 tools:
+  - name: API Commons Rate Limits schema + validator
+    url: https://github.com/api-commons/rate-limits
+    license: Apache-2.0
+    category: Machine-readable schema
   - name: Kong Rate Limiting
     url: https://docs.konghq.com/hub/kong-inc/rate-limiting/
     category: Gateway plugin


### PR DESCRIPTION
`api-commons/rate-limits` is now **public** (Apache-2.0), so the property can stop claiming to be pointer-only.

Closes #26.

- `machineReadable: false` → `true`
- `yaml_example` now shows the `RateLimits` property envelope with `data` — the form the schema actually validates — instead of a bare `url` pointer
- Schema repo added under `standards` and `tools`
- Listed with the other building blocks in the README

## What happened in the schema repo first

The repo could not ship as it stood. Measured against the schema it published alongside its own data, across 76 entries: **38** had a comma-formatted string as `limit` where the schema declared `number`, **49** were missing the required `domains`, **49** were missing the required `userMultiplied`, and `metric` was split three ways (`token` 40 / `tokens` 9 / `request` 27). Every entry in the OpenAI and Gemini sections failed.

Two factual errors, now fixed: every Claude "Input Tokens" entry was tagged `domains: - api.openai.com` — Anthropic models pointing at OpenAI's host. And some Gemini entries describe requests per minute while carrying `metric: token`.

What changed there:
- Real `$id`, title and per-field descriptions, replacing `title: Generated schema for Root`
- Accepts **both** forms — a bare list, and the `RateLimits` property envelope as it appears in an `apis.yml`
- `metric` and `timeframe` are enums; `metric` is singular and gains `input-token` / `output-token`, since those are priced and capped separately
- `domains` and `userMultiplied` became **optional** — most published limits are quoted per model or per plan without a host, so requiring them made the schema reject correct data
- Adds `tier`, `url`, `source_date`
- `rate-limits-example-1.yml` is now a standalone illustrative document on `example.com`; `rate-limits-example-2.yml` is the same limits in the envelope form
- The Claude/OpenAI/Gemini capture moved to `drafts/` behind an UNVERIFIED banner — the numbers have never been checked against the providers' own docs and the model roster is stale
- `validate.py`, which reports the offending field rather than "not valid under any of the given schemas"
- Apache-2.0 LICENSE, matching the rest of the org

**Still outstanding:** real provider rate limits need a sourced pass, with `url` and `source_date` on every entry. That is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)