### PR TITLE
Four properties become machine-readable — wire in the new schema repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ both humans and agents can consume it. Each lives in its own repo under
 - [**use-cases**](https://github.com/api-commons/use-cases) — the use cases an API serves.
 - [**vocabulary**](https://github.com/api-commons/vocabulary) — shared words and definitions for API operations.
 - [**plans**](https://github.com/api-commons/plans) — access plans, tiers, and pricing.
+- [**rate-limits**](https://github.com/api-commons/rate-limits) — the quotas an API enforces, machine-readably.
+- [**versioning**](https://github.com/api-commons/versioning) — how an API is versioned, and which versions are reachable.
+- [**features**](https://github.com/api-commons/features) — what an API can do, tied to the operations behind each claim.
+- [**benefits**](https://github.com/api-commons/benefits) — the outcomes an API claims, with the measure and the evidence.
+- [**integrations**](https://github.com/api-commons/integrations) — the connector catalog, resolvable to the providers on the other end.
 - [**change-log**](https://github.com/api-commons/change-log) — publish an API's changelog, machine-readably.
 - [**road-map**](https://github.com/api-commons/road-map) — publish an API's roadmap, machine-readably.
 - [**interface-license**](https://github.com/api-commons/interface-license) — apply an open license to your API's interface (its surface, not its implementation).

--- a/_common/benefits.md
+++ b/_common/benefits.md
@@ -1,0 +1,111 @@
+---
+name: Benefits
+description: >-
+  The outcomes an API claims to produce for the people who adopt it — not what it does,
+  but what changes for them. Benefits sit one level above features. A feature is a
+  capability; a benefit is the result someone expects from using it. This is the softest
+  thing an API publishes and the first thing a buyer reads, which is exactly why it is
+  worth making machine-readable. The point is not to make marketing rigorous, it is to
+  make it accountable — a benefit that names its audience, states the measure that would
+  have to move for it to be true, and links to evidence that it did is a different object
+  from one that does none of those, and publishing them in the same shape makes the
+  difference visible without anyone having to argue about it.
+image: /images/values.png
+url: '#'
+machineReadable: true
+source: business
+tags:
+  - Benefits
+  - Outcomes
+  - Value
+  - Marketing
+aliases:
+  - Value Proposition
+  - Outcomes
+  - Why Use This API
+  - Business Value
+yaml_example: |
+  - name: Benefits
+    type: Benefits
+    url: https://example.com/benefits
+    source_date: '2026-08-17'
+    data:
+      - name: Reduce onboarding time
+        description: Get a new customer live without a services engagement.
+        audience: business
+        category: speed
+        metric: days from contract signature to first successful call
+        evidence_url: https://example.com/case-studies/onboarding
+
+standards:
+  - name: API Commons Benefits schema
+    url: https://github.com/api-commons/benefits
+    kind: API Commons (Apache-2.0)
+  - name: schema.org Offer
+    url: https://schema.org/Offer
+    kind: Schema.org
+  - name: schema.org Product
+    url: https://schema.org/Product
+    kind: Schema.org
+  - name: schema.org Review
+    url: https://schema.org/Review
+    kind: Schema.org
+
+openapi_expression:
+  - field: info.description
+    spec: OpenAPI 3.x
+    description: Where the top-level value claim usually restates itself, in the provider's own words.
+  - field: info.summary
+    spec: OpenAPI 3.1
+    description: A short statement of what the API is for — in practice, the benefit compressed to a line.
+  - field: externalDocs
+    spec: OpenAPI 3.x
+    description: Can point at the benefits or case-study page substantiating the claims.
+
+risk:
+  compliance:
+    - FTC Act §5 — substantiation for advertising claims
+    - EU Directive 2005/29/EC — unfair commercial practices, including unsubstantiated claims
+  security_implications: >-
+    Benefit claims about security and compliance are the ones that cause real damage when
+    they are loose. "Offload integration security" and "SOC 2 compliant" are routinely
+    read as stronger than they are — offloading moves credentials to a different trust
+    boundary rather than eliminating them, and a provider's certification does not
+    transfer to its consumer. State which obligations actually move and which stay,
+    especially where a shared-responsibility boundary is involved.
+
+tools:
+  - name: API Commons Benefits schema + validator
+    url: https://github.com/api-commons/benefits
+    license: Apache-2.0
+    category: Machine-readable schema
+
+metrics:
+  - name: benefits_with_metric
+    description: Share of published benefit claims that name a measure which would have to move for the claim to be true.
+  - name: benefits_with_evidence
+    description: Share of claims linked to a case study, benchmark, or report.
+  - name: benefits_without_audience
+    description: Count of claims that name no audience — usually addressed to everyone and landing with no one.
+  - name: benefit_to_feature_coverage
+    description: Share of claims traceable to a named feature that delivers them.
+
+examples:
+  - provider: Stripe
+    url: https://stripe.com/payments
+    note: Outcome-led product pages that lead with what changes for the business, with features underneath.
+  - provider: Twilio
+    url: https://www.twilio.com/en-us/messaging
+    note: Per-channel value claims paired with customer stories.
+  - provider: Plaid
+    url: https://plaid.com/
+    note: Benefits framed separately for developers and for the institutions buying.
+
+related_properties:
+  - features
+  - use-cases
+  - solutions
+  - pricing
+  - plans
+  - compare
+---

--- a/_common/features.md
+++ b/_common/features.md
@@ -3,7 +3,7 @@ name: Features
 description: A summary of what an API can do — the consumer-facing capability list that bridges marketing claims and reference documentation. Features pages are how prospective consumers evaluate fit before they read the reference, and how internal teams confirm parity with competitors. A clear features pointer lets discovery tools surface capability summaries without crawling the entire docs site.
 image: /images/features.png
 url: '#'
-machineReadable: false
+machineReadable: true
 source: commons
 tags:
   - Discovery
@@ -16,10 +16,24 @@ aliases:
   - Product Features
   - What You Can Do
 yaml_example: |
-  - type: Features
+  - name: Features
+    type: Features
     url: https://example.com/features
+    source_date: '2026-08-17'
+    data:
+      - name: Bulk send
+        description: Send the same message to up to 10,000 recipients in one request.
+        category: Messaging
+        status: ga
+        tiers:
+          - Pro
+        operations:
+          - createBulkSend
 
 standards:
+  - name: API Commons Features schema
+    url: https://github.com/api-commons/features
+    kind: API Commons (Apache-2.0)
   - name: schema.org Product
     url: https://schema.org/Product
     kind: Schema.org
@@ -41,6 +55,12 @@ openapi_expression:
 risk:
   security_implications: Features pages occasionally enumerate capabilities (admin actions, data exports, write operations) that the reference docs gate behind elevated scopes — making them an accidental scope-discovery surface for attackers. Keep the features list aligned with what is actually authorized at the default tier.
 
+tools:
+  - name: API Commons Features schema + validator
+    url: https://github.com/api-commons/features
+    license: Apache-2.0
+    category: Machine-readable schema
+
 metrics:
   - name: features_to_signup_conversion
     description: Share of features-page visits that convert to a signup or contact-sales event.
@@ -61,6 +81,7 @@ examples:
     note: Platform-level features index linking into per-feature deep dives.
 
 related_properties:
+  - benefits
   - documentation
   - use-cases
   - pricing

--- a/_common/integrations.md
+++ b/_common/integrations.md
@@ -3,7 +3,7 @@ name: Integrations
 description: Providing ready to go integrations with other APIs has become commonplace as part of Software as a Service (SaaS) solutions, and help demonstrate the value an API provides. Demonstrating how an API can be used with the existing platforms that API consumers are already using help make your APIs more useful and sticky for developers.
 image: /images/integrations.png
 url: '#'
-machineReadable: false
+machineReadable: true
 source: concept
 tags:
   - Integrations
@@ -13,10 +13,26 @@ aliases:
   - Integration Catalog
   - Partner Integrations
 yaml_example: |
-  - type: Integrations
-    url: https://developers.example.com/integrations
+  - name: Connectors
+    type: Integrations
+    url: https://example.com/connectors/
+    source_date: '2026-08-17'
+    count: 412
+    data:
+      - name: Salesforce
+        url: https://example.com/connectors/salesforce/
+        partner_domain: salesforce.com
+        category: CRM
+        kind: connector
+        direction: bidirectional
+        built_by: first-party
+        status: ga
+        auth: oauth2
 
 standards:
+  - name: API Commons Integrations schema
+    url: https://github.com/api-commons/integrations
+    kind: API Commons (Apache-2.0)
   - name: OpenAPI Specification 3.1
     url: https://spec.openapis.org/oas/v3.1.0
     kind: OpenAPI Initiative
@@ -68,6 +84,10 @@ risk:
   governance: Unversioned integration manifests cause silent breakage across iPaaS catalogs. Treat connector metadata as a versioned artifact alongside the API description.
 
 tools:
+  - name: API Commons Integrations schema + validator
+    url: https://github.com/api-commons/integrations
+    license: Apache-2.0
+    category: Machine-readable schema
   - name: Zapier developer platform
     url: https://platform.zapier.com/
     category: iPaaS

--- a/_common/versioning.md
+++ b/_common/versioning.md
@@ -3,7 +3,7 @@ name: Versioning
 description: The details of how an API is being versioned with information about how change is being communicated with consumers across multiple channels. Having a formal approach to versioning published and communicated helps lay the ground work for change, but also keeps API consumers aligned with what has changed.
 image: /images/versioning.png
 url: '#'
-machineReadable: false
+machineReadable: true
 source: concept
 tags:
   - Change
@@ -14,10 +14,29 @@ aliases:
   - SemVer
   - CalVer
 yaml_example: |
-  - type: Versioning
+  - name: Versioning
+    type: Versioning
     url: https://developers.example.com/versioning
+    source_date: '2026-08-17'
+    data:
+      scheme: sequential
+      location: path
+      path_pattern: /v{version}
+      current: '3'
+      default: '2'
+      required: true
+      pinning: per-request
+      supported:
+        - version: '2'
+          status: deprecated
+          sunset: '2027-02-01'
+        - version: '3'
+          status: current
 
 standards:
+  - name: API Commons Versioning schema
+    url: https://github.com/api-commons/versioning
+    kind: API Commons (Apache-2.0)
   - name: Semantic Versioning 2.0.0
     url: https://semver.org/spec/v2.0.0.html
     kind: Community spec
@@ -106,6 +125,10 @@ risk:
   security_implications: Ambiguous versioning lets clients pin to vulnerable behaviour or silently roll forward into untested code paths. Explicit, negotiated versions plus a published compatibility policy reduce regression-driven security incidents.
 
 tools:
+  - name: API Commons Versioning schema + validator
+    url: https://github.com/api-commons/versioning
+    license: Apache-2.0
+    category: Machine-readable schema
   - name: oasdiff
     url: https://github.com/oasdiff/oasdiff
     license: Apache-2.0


### PR DESCRIPTION
Four new public repos in the org, each following the `plans` / `tiers` / `rate-limits` pattern — a JSON Schema 2020-12, two illustrative examples on `example.com` (a standalone document and the `apis.yml` property envelope), a validator, Apache-2.0.

| Repo | Issue |
| --- | --- |
| [api-commons/versioning](https://github.com/api-commons/versioning) | #27 |
| [api-commons/features](https://github.com/api-commons/features) | #24 |
| [api-commons/benefits](https://github.com/api-commons/benefits) | #25 |
| [api-commons/integrations](https://github.com/api-commons/integrations) | #23 |

Closes #23, #24, #25, #27.

## Site changes

- **`benefits.md` is new.** The property did not exist at all — the collection had `features`, `solutions` and `use-cases`, but nothing for the outcomes an API claims.
- `versioning`, `features` and `integrations` flip `machineReadable: false` → `true`.
- Each `yaml_example` now shows the property envelope with `data` — the form the schema actually validates — instead of a bare `url` pointer.
- Schema repos added under `standards` and `tools` on all four.
- `features` gains a `tools` block, which it did not have, and lists `benefits` under `related_properties`.
- README lists all five new building blocks, `rate-limits` included.

## The schema designs are opinionated — here's why

**Versioning** carries `default`, `required` and `pinning`. Prose versioning pages answer *"what happens if I send no version"* inconsistently and *"is it pinned per request or per account"* almost never — and those two decide whether client code is correct. `breaking_change_definition_url` is in there because without it, "we don't make breaking changes" is unfalsifiable.

**Features** carries `operations` — the operationIds behind each advertised feature. That turns "advertised but not in the API" into a query you run against the OpenAPI rather than an argument. `status: announced` is deliberately distinct from `preview`, because things reach a features page before they ship, and a consumer will ask about them either way.

**Benefits** carries `audience`, `metric` and `evidence_url`. Not to make marketing rigorous — to make it **accountable**. Its examples deliberately include claims with no metric and no evidence, including one pure slogan, because real benefits pages are like that and the schema's job is to make that legible rather than hide it.

**Integrations** carries `partner_domain`, which resolves a catalog name to a company and makes a catalog *joinable* to a provider index; `built_by`, because a community connector and a first-party one look identical on a marketplace page and carry completely different support expectations; and `count` on the property, recorded separately from the length of `data`, so a sampled catalog cannot silently read as a complete one. `example-2` shows `count: 412` against nine entries on purpose.

## Verification

Every example validates. Every enum was checked against a negative control (a deliberately bad document, confirming the schema rejects it and names the offending field). The site builds clean and all four pages render.

**No real provider data in any of them.** Real catalogs need a sourced pass with `url` and `source_date` on every entry — deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
