### PR TITLE
Bases, starters, RFC 9457 across the catalog, and a home for the rule catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ blocks and the index of tools:
 - `scripts/` — helpers that generate site data (e.g. rulesets from the API Commons
   rule catalog).
 
+> **`scripts/generate-spotlight.py` needs a sibling checkout.** It reads the Spotlight
+> rule catalog from `../spotlight-validator/rules/all-rules.yaml` — a **private** repo
+> that is not vendored here. `_data/spotlight_rules.json`, `assets/rulesets/*` and the
+> `/rules/` and `/rulesets/` pages are all **generated** from it, so never hand-edit
+> them; the next run overwrites your change. Clone it alongside this repo before
+> regenerating:
+>
+> ```
+> git clone https://github.com/api-commons/spotlight-validator.git ../spotlight-validator
+> ```
+
 ## Building blocks
 
 Each building block is a machine-readable property or artifact that describes one facet

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ blocks and the index of tools:
 
 - `_common/` — **Common Schema**: shared operational properties every API can adopt.
 - `_community/` — **Community Schema**: community-contributed properties.
+- `_starters/` — the smallest correct version of each artifact (OpenAPI, APIs.json, JSON Schema).
 - `_blueprints/` — reusable API blueprints.
 - `_overlays/` — OpenAPI Overlays for applying properties to existing descriptions.
 - `_rulesets/` / `rules/` / `rulesets/` — governance rules and rulesets.
@@ -72,6 +73,7 @@ both humans and agents can consume it. Each lives in its own repo under
 - [**api-authorization**](https://github.com/api-commons/api-authorization) — a jurisdiction-neutral, two-tier, machine-checkable profile for securing APIs with OAuth 2.1 and FAPI 2.0.
 - [**problem-details-for-http-apis**](https://github.com/api-commons/problem-details-for-http-apis) — a base for using RFC 9457 Problem Details in your API, with a [Spectral ruleset](https://github.com/api-commons/spectral-problem-details-ruleset) that checks conformance.
 - [**json-api**](https://github.com/api-commons/json-api) — schemas and governance for the JSON:API standard.
+- [**starters**](https://github.com/api-commons/starters) — the smallest correct version of each artifact: a starter OpenAPI, APIs.json, and JSON Schema you copy and grow.
 - [**train-travel**](https://github.com/api-commons/train-travel) — an OpenAPI + APIs.json template for a Train Travel API, handy for demos and testing.
 - [**accounts**](https://github.com/api-commons/accounts) — a base Accounts API: the account lifecycle every service reinvents, described once.
 - [**images**](https://github.com/api-commons/images) — a base Images API: upload, metadata, renditions, and deletion.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ both humans and agents can consume it. Each lives in its own repo under
 - [**problem-details-for-http-apis**](https://github.com/api-commons/problem-details-for-http-apis) — a base for using RFC 9457 Problem Details in your API, with a [Spectral ruleset](https://github.com/api-commons/spectral-problem-details-ruleset) that checks conformance.
 - [**json-api**](https://github.com/api-commons/json-api) — schemas and governance for the JSON:API standard.
 - [**train-travel**](https://github.com/api-commons/train-travel) — an OpenAPI + APIs.json template for a Train Travel API, handy for demos and testing.
+- [**accounts**](https://github.com/api-commons/accounts) — a base Accounts API: the account lifecycle every service reinvents, described once.
+- [**images**](https://github.com/api-commons/images) — a base Images API: upload, metadata, renditions, and deletion.
+- [**videos**](https://github.com/api-commons/videos) — a base Videos API: upload, transcoding, playback renditions, and captions.
 - [**examples**](https://github.com/api-commons/examples) — shared examples for the building blocks and the APIs.json ecosystem.
 - [**snacks-twilio-messages**](https://github.com/api-commons/snacks-twilio-messages) — an API Snack for AI: send a message with Twilio.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ tool lives at its own subdomain of **apicommons.org**:
 | **Spec Review** | [review.apicommons.org](https://review.apicommons.org) | A ref-resolving design-diff for OpenAPI/AsyncAPI/Arazzo — resolve `$ref`, flag breaking changes, and get a copyable Markdown summary for the PR. |
 | **Spectral OWASP Ruleset** | [github.com/api-commons/spectral-owasp-ruleset](https://github.com/api-commons/spectral-owasp-ruleset) | A grounded Spectral ruleset for the OWASP API Security Top 10. |
 | **Spectral Problem Details Ruleset** | [github.com/api-commons/spectral-problem-details-ruleset](https://github.com/api-commons/spectral-problem-details-ruleset) | A grounded Spectral ruleset for RFC 9457 Problem Details — check that your error responses really are problem details. |
+| **Spectral FHIR Ruleset** | [github.com/api-commons/spectral-fhir-ruleset](https://github.com/api-commons/spectral-fhir-ruleset) | A grounded Spectral ruleset for HL7 FHIR R4/R5 — check that a FHIR-shaped API is actually FHIR. |
 | **Spectral Reporter** | [reporter.apicommons.org](https://reporter.apicommons.org) | Turn a Spectral lint run into a self-contained HTML governance report (with SARIF + trends). |
 | **Spectral Ruleset Studio** | [studio.apicommons.org](https://studio.apicommons.org) | Turn a prose style guide into an owned, grounded, well-named Spectral ruleset. |
 | **Toolsmith** | [toolsmith.apicommons.org](https://toolsmith.apicommons.org) | Forge MCP tools and Agent Skills from your OpenAPI — a workbench for designing the agent layer of an API. |

--- a/_base/accounts.md
+++ b/_base/accounts.md
@@ -1,8 +1,40 @@
 ---
 name: Accounts
-description: We need an account for everything these days, and if you are a developer you likely have many accounts associated with your APIs. This business of APIs is the first place we should be standardizing and stopping reinventing the wheels and be utilizing the same base account API for every new service we launch, helping streamlining onboarding of users and API consumer accounts.
+description: >-
+  We need an account for everything these days. Every new service reinvents the same account resource, the same onboarding flow, and the same set of errors — each one slightly different, which is exactly what makes integration expensive. This is a base Accounts API you copy into your own service: list, create, read, update and close. Updates are RFC 7396 JSON Merge Patch and writes are conditional on an ETag, so a client changes one field without sending the whole account back and without clobbering a concurrent write. Errors are RFC 9457 problem details, identical to every other base.
 image: /images/accounts.png
-url: #
+url: https://github.com/api-commons/accounts
 tags:
-  - Accounts 
+  - Accounts
+  - Onboarding
+  - Users
+  - OpenAPI
+
+apis:
+
+  - name: OpenAPI
+    description: OpenAPI 3.1 for the base Accounts API — list, create, read, merge-patch and close.
+    properties:
+      - type: OpenAPI
+        url: https://raw.githubusercontent.com/api-commons/accounts/main/openapi.yml
+
+  - name: APIs.json
+    description: The APIs.json index for this base.
+    properties:
+      - type: APIsJSON
+        url: https://raw.githubusercontent.com/api-commons/accounts/main/apis.yml
+
+  - name: Repository
+    description: The repository for the base.
+    properties:
+      - type: GitHubRepository
+        url: https://github.com/api-commons/accounts
+
+  - name: Spectral Ruleset
+    description: >-
+      The errors in this base are RFC 9457 problem details, checked by the API Commons
+      Problem Details ruleset. The base lints clean under it.
+    properties:
+      - type: GitHubRepository
+        url: https://github.com/api-commons/spectral-problem-details-ruleset
 ---

--- a/_base/images.md
+++ b/_base/images.md
@@ -1,9 +1,40 @@
 ---
 name: Images API
-description: Images have been done, and there is no reason we shouldn't all be using the same image API for all of the base images of our applications. A common images API would go a long way towards helping companies focus on what they do best, and not reinventing the wheel, while also promoting interoperability.
+description: >-
+  Images have been done. There is no good reason every application invents its own upload endpoint, its own metadata shape, and its own way of asking for a smaller version of the same picture. This is a base Images API you copy into your own service. Upload is two steps — create the record, then PUT the bytes to a short-lived URL — which keeps large binaries off the JSON API and means a failed upload does not lose the metadata. Renditions are requested rather than enumerated, and `alt` is on the base, because an image API that makes the text alternative easy to skip produces an inaccessible product downstream. Errors are RFC 9457 problem details, identical to every other base.
 image: /images/images.png
-url: #
+url: https://github.com/api-commons/images
 tags:
   - Images
-  - Photos 
+  - Photos
+  - Media
+  - OpenAPI
+
+apis:
+
+  - name: OpenAPI
+    description: OpenAPI 3.1 for the base Images API — upload, metadata, renditions and deletion.
+    properties:
+      - type: OpenAPI
+        url: https://raw.githubusercontent.com/api-commons/images/main/openapi.yml
+
+  - name: APIs.json
+    description: The APIs.json index for this base.
+    properties:
+      - type: APIsJSON
+        url: https://raw.githubusercontent.com/api-commons/images/main/apis.yml
+
+  - name: Repository
+    description: The repository for the base.
+    properties:
+      - type: GitHubRepository
+        url: https://github.com/api-commons/images
+
+  - name: Spectral Ruleset
+    description: >-
+      The errors in this base are RFC 9457 problem details, checked by the API Commons
+      Problem Details ruleset. The base lints clean under it.
+    properties:
+      - type: GitHubRepository
+        url: https://github.com/api-commons/spectral-problem-details-ruleset
 ---

--- a/_base/videos.md
+++ b/_base/videos.md
@@ -1,9 +1,40 @@
 ---
 name: Videos API
-description: Videos have been done, and there is no reason we shouldn't all be using the same image API for all of the base videos of our applications. A common videos API would go a long way towards helping companies focus on what they do best, and not reinventing the wheel, while also promoting interoperability.
+description: >-
+  Videos have been done. Every product that handles video rebuilds the same upload flow, the same transcoding wait, and the same playback URLs, slightly differently each time. This is a base Videos API you copy into your own service — the sibling of the Images base, deliberately sharing its shape, with the one difference that actually matters: video is not ready when the bytes finish uploading. Transcoding takes real time, so status moves through processing and the base ships webhooks rather than asking clients to poll. Captions are a first-class sub-resource. Errors are RFC 9457 problem details, identical to every other base — including on the failure webhook.
 image: /images/videos.png
-url: #
+url: https://github.com/api-commons/videos
 tags:
   - Videos
-  - Photos 
+  - Media
+  - Captions
+  - OpenAPI
+
+apis:
+
+  - name: OpenAPI
+    description: OpenAPI 3.1 for the base Videos API — upload, transcoding, renditions, captions and webhooks.
+    properties:
+      - type: OpenAPI
+        url: https://raw.githubusercontent.com/api-commons/videos/main/openapi.yml
+
+  - name: APIs.json
+    description: The APIs.json index for this base.
+    properties:
+      - type: APIsJSON
+        url: https://raw.githubusercontent.com/api-commons/videos/main/apis.yml
+
+  - name: Repository
+    description: The repository for the base.
+    properties:
+      - type: GitHubRepository
+        url: https://github.com/api-commons/videos
+
+  - name: Spectral Ruleset
+    description: >-
+      The errors in this base are RFC 9457 problem details, checked by the API Commons
+      Problem Details ruleset. The base lints clean under it.
+    properties:
+      - type: GitHubRepository
+        url: https://github.com/api-commons/spectral-problem-details-ruleset
 ---

--- a/_config.yml
+++ b/_config.yml
@@ -67,7 +67,10 @@ collections:
     permalink: /rules/:path/    
   rulesets:
     output: true
-    permalink: /rulesets/:path/      
+    permalink: /rulesets/:path/
+  starters:
+    output: true
+    permalink: /starters/:path/      
 
 defaults:
 
@@ -105,4 +108,9 @@ defaults:
       path:         ""
       type:         rulesets
     values:
-      layout:       rulesets                 
+      layout:       rulesets
+  - scope:
+      path:         ""
+      type:         starters
+    values:
+      layout:       starters                 

--- a/_data/spotlight_rules.json
+++ b/_data/spotlight_rules.json
@@ -11523,7 +11523,7 @@
      "slug": "openapi-response-error-match-problem-schema",
      "name": "Response Error Match Problem Schema",
      "severity": "info",
-     "description": "WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. This rule inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC7807: `status`, `title` and `detail`. An example of a valid payload is ``` { \"title\": \"Not Found\", \"status\": 404, \"detail\": \"Book does not exist; id: 123\" } ``` See recommendation RAC_REST_NAME_007.",
+     "description": "WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. This rule inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC 9457: `status`, `title` and `detail`. An example of a valid payload is ``` { \"title\": \"Not Found\", \"status\": 404, \"detail\": \"Book does not exist; id: 123\" } ``` See recommendation RAC_REST_NAME_007.",
      "experience": [
       "error-handling",
       "consistency"
@@ -11540,8 +11540,8 @@
       "response-error-match-problem-schema": {
        "title": "Response Error Match Problem Schema",
        "reference": "https://spotlight-rules.com/spec/rules/openapi/response-error-match-problem-schema/",
-       "description": "WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. This rule inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC7807: `status`, `title` and `detail`. An example of a valid payload is ``` { \"title\": \"Not Found\", \"status\": 404, \"detail\": \"Book does not exist; id: 123\" } ``` See recommendation RAC_REST_NAME_007.",
-       "message": "Your schema doesn't seem to match RFC7807. Are you sure it is ok? {{path}}",
+       "description": "WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. This rule inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC 9457: `status`, `title` and `detail`. An example of a valid payload is ``` { \"title\": \"Not Found\", \"status\": 404, \"detail\": \"Book does not exist; id: 123\" } ``` See recommendation RAC_REST_NAME_007.",
+       "message": "Your schema doesn't seem to match RFC 9457. Are you sure it is ok? {{path}}",
        "severity": "info",
        "given": "$.paths.[*].responses[?(@property.match(/^(4|5|default)/))][[schema]]",
        "then": {
@@ -11574,7 +11574,7 @@
         "experience:error-handling",
         "experience:consistency"
        ],
-       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-match-problem-schema' (Response Error Match Problem Schema). Requirement: WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. This rule inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC7807: `status`, `title` and `detail`. An example of a valid payload is ``` { \"title\": \"Not Found\", \"status\": 404, \"detail\": \"Book does not exist; id: 123\" } ``` See recommendation RAC_REST_NAME_007. To fix: Adjust the targeted value so it conforms to the schema this rule requires. This rule is evaluated at the JSONPath `$.paths.[*].responses[?(@property.match(/^(4|5|default)/))][[schema]]` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
+       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-match-problem-schema' (Response Error Match Problem Schema). Requirement: WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. This rule inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC 9457: `status`, `title` and `detail`. An example of a valid payload is ``` { \"title\": \"Not Found\", \"status\": 404, \"detail\": \"Book does not exist; id: 123\" } ``` See recommendation RAC_REST_NAME_007. To fix: Adjust the targeted value so it conforms to the schema this rule requires. This rule is evaluated at the JSONPath `$.paths.[*].responses[?(@property.match(/^(4|5|default)/))][[schema]]` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
       }
      }
     },
@@ -11620,7 +11620,7 @@
      "slug": "openapi-response-error-schema-problem-property-names",
      "name": "Response Error Schema Problem Property Names",
      "severity": "info",
-     "description": "WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Errors should return RFC7807 objects. Instead, this schema seems to use non standard properties such as: `message`, `msg` and `code`. An error of the following form ``` { \"msg\": \"Book with id: 123 does not exist.\", \"code\": 6063 } ``` can be expressed in RFC7807 with ``` { \"detail\": \"Book with id: 123 does not exist.\", \"type\": \"https://api.example/v1/errors/6063\", \"status\": 404, \"title\": \"Not Found\" } ``` Returning an URI in `type`, instead of an opaque `code` can help the client in better identifying the error; moreover the URI though it should not be dereferenced automatically, can return an actual resource providing guidance in addressing the issue. See recommendation RAC_REST_NAME_007.",
+     "description": "WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Errors should return RFC 9457 objects. Instead, this schema seems to use non standard properties such as: `message`, `msg` and `code`. An error of the following form ``` { \"msg\": \"Book with id: 123 does not exist.\", \"code\": 6063 } ``` can be expressed in RFC 9457 with ``` { \"detail\": \"Book with id: 123 does not exist.\", \"type\": \"https://api.example/v1/errors/6063\", \"status\": 404, \"title\": \"Not Found\" } ``` Returning an URI in `type`, instead of an opaque `code` can help the client in better identifying the error; moreover the URI though it should not be dereferenced automatically, can return an actual resource providing guidance in addressing the issue. See recommendation RAC_REST_NAME_007.",
      "experience": [
       "error-handling",
       "consistency"
@@ -11636,8 +11636,8 @@
       "response-error-schema-problem-property-names": {
        "title": "Response Error Schema Problem Property Names",
        "reference": "https://spotlight-rules.com/spec/rules/openapi/response-error-schema-problem-property-names/",
-       "description": "WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Errors should return RFC7807 objects. Instead, this schema seems to use non standard properties such as: `message`, `msg` and `code`. An error of the following form ``` { \"msg\": \"Book with id: 123 does not exist.\", \"code\": 6063 } ``` can be expressed in RFC7807 with ``` { \"detail\": \"Book with id: 123 does not exist.\", \"type\": \"https://api.example/v1/errors/6063\", \"status\": 404, \"title\": \"Not Found\" } ``` Returning an URI in `type`, instead of an opaque `code` can help the client in better identifying the error; moreover the URI though it should not be dereferenced automatically, can return an actual resource providing guidance in addressing the issue. See recommendation RAC_REST_NAME_007.",
-       "message": "Error response doesn't seem to match RFC7807. Are you sure it is ok? {{path}}",
+       "description": "WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Errors should return RFC 9457 objects. Instead, this schema seems to use non standard properties such as: `message`, `msg` and `code`. An error of the following form ``` { \"msg\": \"Book with id: 123 does not exist.\", \"code\": 6063 } ``` can be expressed in RFC 9457 with ``` { \"detail\": \"Book with id: 123 does not exist.\", \"type\": \"https://api.example/v1/errors/6063\", \"status\": 404, \"title\": \"Not Found\" } ``` Returning an URI in `type`, instead of an opaque `code` can help the client in better identifying the error; moreover the URI though it should not be dereferenced automatically, can return an actual resource providing guidance in addressing the issue. See recommendation RAC_REST_NAME_007.",
+       "message": "Error response doesn't seem to match RFC 9457. Are you sure it is ok? {{path}}",
        "severity": "info",
        "given": "$.[responses][?(@property.match(/^(4|5|default)/))][[schema]][properties].*~",
        "then": {
@@ -11657,7 +11657,7 @@
         "experience:error-handling",
         "experience:consistency"
        ],
-       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-schema-problem-property-names' (Response Error Schema Problem Property Names). Requirement: WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Errors should return RFC7807 objects. Instead, this schema seems to use non standard properties such as: `message`, `msg` and `code`. An error of the following form ``` { \"msg\": \"Book with id: 123 does not exist.\", \"code\": 6063 } ``` can be expressed in RFC7807 with ``` { \"detail\": \"Book with id: 123 does not exist.\", \"type\": \"https://api.example/v1/errors/6063\", \"status\": 404, \"title\": \"Not Found\" } ``` Returning an URI in `type`, instead of an opaque `code` can help the client in better identifying the error; moreover the URI though it should not be dereferenced automatically, can return an actual resource providing guidance in addressing the issue. See recommendation RAC_REST_NAME_007. To fix: Ensure `@key` does NOT match the regular expression `message|code|msg`; rename or rewrite any value that does. This rule is evaluated at the JSONPath `$.[responses][?(@property.match(/^(4|5|default)/))][[schema]][properties].*~` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
+       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-schema-problem-property-names' (Response Error Schema Problem Property Names). Requirement: WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Errors should return RFC 9457 objects. Instead, this schema seems to use non standard properties such as: `message`, `msg` and `code`. An error of the following form ``` { \"msg\": \"Book with id: 123 does not exist.\", \"code\": 6063 } ``` can be expressed in RFC 9457 with ``` { \"detail\": \"Book with id: 123 does not exist.\", \"type\": \"https://api.example/v1/errors/6063\", \"status\": 404, \"title\": \"Not Found\" } ``` Returning an URI in `type`, instead of an opaque `code` can help the client in better identifying the error; moreover the URI though it should not be dereferenced automatically, can return an actual resource providing guidance in addressing the issue. See recommendation RAC_REST_NAME_007. To fix: Ensure `@key` does NOT match the regular expression `message|code|msg`; rename or rewrite any value that does. This rule is evaluated at the JSONPath `$.[responses][?(@property.match(/^(4|5|default)/))][[schema]][properties].*~` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
       }
      }
     },
@@ -11703,7 +11703,7 @@
      "slug": "openapi-response-error-use-problem-json",
      "name": "Response Error Use Problem JSON",
      "severity": "info",
-     "description": "All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 7807).",
+     "description": "All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 9457, which obsoleted RFC 7807).",
      "experience": [
       "consistency",
       "error-handling"
@@ -11720,7 +11720,7 @@
       "response-error-use-problem-json": {
        "title": "Response Error Use Problem JSON",
        "reference": "https://spotlight-rules.com/spec/rules/openapi/response-error-use-problem-json/",
-       "description": "All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 7807).",
+       "description": "All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 9457, which obsoleted RFC 7807).",
        "message": "Error response documents MUST use the application/problem+json media type: {{error}}",
        "severity": "info",
        "given": "$.paths..responses[?( @property >= 400 && @property < 600)].content[*]~",
@@ -11743,7 +11743,7 @@
         "experience:consistency",
         "experience:error-handling"
        ],
-       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-use-problem-json' (Response Error Use Problem JSON). Requirement: All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 7807). To fix: Set the targeted value to one of the allowed values: application/problem+json. This rule is evaluated at the JSONPath `$.paths..responses[?( @property >= 400 && @property < 600)].content[*]~` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
+       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-use-problem-json' (Response Error Use Problem JSON). Requirement: All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 9457, which obsoleted RFC 7807). To fix: Set the targeted value to one of the allowed values: application/problem+json. This rule is evaluated at the JSONPath `$.paths..responses[?( @property >= 400 && @property < 600)].content[*]~` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
       }
      }
     },
@@ -11751,7 +11751,7 @@
      "slug": "openapi-response-error-use-problem-type",
      "name": "Response Error Use Problem Type",
      "severity": "info",
-     "description": "Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Error responses should return one of the media-type defined in RFC7807: - `application/problem+json` - `application/problem+xml` An example of a valid response: ``` responses: \"503\": content: application/problem+json: schema: ... ```.",
+     "description": "Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Error responses should return one of the media-type defined in RFC 9457: - `application/problem+json` - `application/problem+xml` An example of a valid response: ``` responses: \"503\": content: application/problem+json: schema: ... ```.",
      "experience": [
       "error-handling",
       "consistency"
@@ -11768,8 +11768,8 @@
       "response-error-use-problem-type": {
        "title": "Response Error Use Problem Type",
        "reference": "https://spotlight-rules.com/spec/rules/openapi/response-error-use-problem-type/",
-       "description": "Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Error responses should return one of the media-type defined in RFC7807: - `application/problem+json` - `application/problem+xml` An example of a valid response: ``` responses: \"503\": content: application/problem+json: schema: ... ```.",
-       "message": "Error responses should support RFC7807 in {{path}}.",
+       "description": "Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Error responses should return one of the media-type defined in RFC 9457: - `application/problem+json` - `application/problem+xml` An example of a valid response: ``` responses: \"503\": content: application/problem+json: schema: ... ```.",
+       "message": "Error responses should support RFC 9457 in {{path}}.",
        "severity": "info",
        "given": "$.paths.[*].responses[?(@property.match(/^(4|5|default)/))].content.*~",
        "then": {
@@ -11792,7 +11792,7 @@
         "experience:error-handling",
         "experience:consistency"
        ],
-       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-use-problem-type' (Response Error Use Problem Type). Requirement: Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Error responses should return one of the media-type defined in RFC7807: - `application/problem+json` - `application/problem+xml` An example of a valid response: ``` responses: \"503\": content: application/problem+json: schema: ... ```. To fix: Set the targeted value to one of the allowed values: application/problem+xml, application/problem+json. This rule is evaluated at the JSONPath `$.paths.[*].responses[?(@property.match(/^(4|5|default)/))].content.*~` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
+       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-use-problem-type' (Response Error Use Problem Type). Requirement: Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly implement an error management strategy, with positive impacts for users. Error responses should return one of the media-type defined in RFC 9457: - `application/problem+json` - `application/problem+xml` An example of a valid response: ``` responses: \"503\": content: application/problem+json: schema: ... ```. To fix: Set the targeted value to one of the allowed values: application/problem+xml, application/problem+json. This rule is evaluated at the JSONPath `$.paths.[*].responses[?(@property.match(/^(4|5|default)/))].content.*~` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
       }
      }
     },
@@ -11800,7 +11800,7 @@
      "slug": "openapi-response-error-use-problem-type-2",
      "name": "Response Error Use Problem Type 2",
      "severity": "info",
-     "description": "Every error response SHOULD support RFC 7807.",
+     "description": "Every error response SHOULD support RFC 9457.",
      "experience": [
       "error-handling",
       "consistency"
@@ -11817,8 +11817,8 @@
       "response-error-use-problem-type-2": {
        "title": "Response Error Use Problem Type 2",
        "reference": "https://spotlight-rules.com/spec/rules/openapi/response-error-use-problem-type-2/",
-       "description": "Every error response SHOULD support RFC 7807.",
-       "message": "Every error response SHOULD support RFC 7807.",
+       "description": "Every error response SHOULD support RFC 9457.",
+       "message": "Every error response SHOULD support RFC 9457.",
        "severity": "info",
        "given": "$.paths...responses[?(@property.match(/^(4|5)/))].content.*~",
        "then": {
@@ -11838,7 +11838,7 @@
         "experience:error-handling",
         "experience:consistency"
        ],
-       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-use-problem-type-2' (Response Error Use Problem Type 2). Requirement: Every error response SHOULD support RFC 7807. To fix: Set the targeted value to one of the allowed values: application/problem+xml, application/problem+json. This rule is evaluated at the JSONPath `$.paths...responses[?(@property.match(/^(4|5)/))].content.*~` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
+       "prompt": "You are editing an OpenAPI document to satisfy the Spotlight API governance rule 'response-error-use-problem-type-2' (Response Error Use Problem Type 2). Requirement: Every error response SHOULD support RFC 9457. To fix: Set the targeted value to one of the allowed values: application/problem+xml, application/problem+json. This rule is evaluated at the JSONPath `$.paths...responses[?(@property.match(/^(4|5)/))].content.*~` \u2014 inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only the complete corrected document, with no commentary."
       }
      }
     },

--- a/_layouts/starters.html
+++ b/_layouts/starters.html
@@ -1,0 +1,58 @@
+---
+layout: default
+---
+<style>.gist-data { max-height: 500px; }</style>
+<div class="d-flex justify-content-between align-items-start mb-3">
+  <h2 class="mb-0 me-3">{{ page.title }}</h2>
+  {% include ai-toolbar.html %}
+</div>
+<img src="{{ page.image }}" class="float-end ms-3 mb-3" width="100">
+<p>{{ page.description }}</p>
+<h3>Tags</h3>
+<ul>
+{% for tag in page.tags %}
+    <li>{{ tag }}</li>
+{% endfor %}
+</ul>
+{% for api in page.apis %}
+    {% for property in api.properties %}
+        {% if property.type == 'GitHubGist' %}
+        <h3>{{ api.name }}</h3>
+        <p>{{ api.description }}</p>
+        <script src="{{ property.url }}"></script>
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+{% comment %}
+  Every entry that is not an embedded gist, rendered as a labelled list.
+  Previously only GitHubRepository was rendered, and every one of them got the
+  text "Visit this Base on GitHub" — which is wrong as soon as a base points at
+  more than one repo (a ruleset, a schema, the spec it implements).
+{% endcomment %}
+{% assign has_resources = false %}
+{% for api in page.apis %}
+  {% for property in api.properties %}
+    {% if property.type != 'GitHubGist' %}{% assign has_resources = true %}{% endif %}
+  {% endfor %}
+{% endfor %}
+
+{% if has_resources %}
+<h3>Resources</h3>
+<ul>
+{% for api in page.apis %}
+  {% for property in api.properties %}
+    {% if property.type != 'GitHubGist' %}
+    <li>
+      <a href="{{ property.url }}" target="_blank" rel="noopener">{{ api.name }}</a>
+      <small class="text-muted">— {{ property.type }}</small>
+      {% if api.description and forloop.first %}<br><small>{{ api.description }}</small>{% endif %}
+    </li>
+    {% endif %}
+  {% endfor %}
+{% endfor %}
+</ul>
+{% endif %}
+
+<p class="text-center"><a href="/starters/"><strong>All Starters</strong></a></p>
+<br>

--- a/_starters/apis-json.md
+++ b/_starters/apis-json.md
@@ -1,0 +1,31 @@
+---
+name: Starter APIs.json
+description: >-
+  The smallest APIs.json document that validates — one index, one API, and the properties a consumer actually needs to find their way in. Where an OpenAPI describes one API's surface, this describes where an API lives, who runs it, and which artifacts sit alongside it: documentation, a portal, a changelog, a status page, terms. Written against specificationVersion 0.22 and validated against the published schema.
+image: /images/api-index.png
+url: https://github.com/api-commons/starters
+tags:
+  - APIs.json
+  - Starter
+  - Discovery
+
+apis:
+
+  - name: The starter
+    description: APIs.json 0.22 — copy this file and edit it.
+    properties:
+      - type: APIsJSON
+        url: https://raw.githubusercontent.com/api-commons/starters/main/starter-apis.yml
+
+  - name: Repository
+    description: Every starter, with a validator that checks them.
+    properties:
+      - type: GitHubRepository
+        url: https://github.com/api-commons/starters
+
+  - name: Specification
+    description: The specification this starter is written against.
+    properties:
+      - type: Specification
+        url: https://apisjson.org
+---

--- a/_starters/json-schema.md
+++ b/_starters/json-schema.md
@@ -1,0 +1,31 @@
+---
+name: Starter JSON Schema
+description: >-
+  The smallest JSON Schema worth copying — an object, typed properties, one constraint, one required field, and a description on everything. Written against 2020-12, the dialect OpenAPI 3.1 uses, so it drops straight into components.schemas with no translation. Its own examples are validated against the properties they sit on, because a starter whose examples do not validate is worse than no starter.
+image: /images/json-schema.png
+url: https://github.com/api-commons/starters
+tags:
+  - JSON Schema
+  - Starter
+  - Contracts
+
+apis:
+
+  - name: The starter
+    description: JSON Schema 2020-12 — copy this file and edit it.
+    properties:
+      - type: JSONSchema
+        url: https://raw.githubusercontent.com/api-commons/starters/main/starter-json-schema.yml
+
+  - name: Repository
+    description: Every starter, with a validator that checks them.
+    properties:
+      - type: GitHubRepository
+        url: https://github.com/api-commons/starters
+
+  - name: Specification
+    description: The specification this starter is written against.
+    properties:
+      - type: Specification
+        url: https://json-schema.org/draft/2020-12/schema
+---

--- a/_starters/openapi.md
+++ b/_starters/openapi.md
@@ -1,0 +1,31 @@
+---
+name: Starter OpenAPI
+description: >-
+  The smallest OpenAPI 3.1 document complete enough to be useful — one resource with a list, a create, and a read by id, and RFC 9457 problem details on every error. It returns zero findings under both spectral:oas and the API Commons Problem Details ruleset, which is the point: whatever you build on top starts from zero, so the first warning you ever see is one you introduced. Copy it, rename the Thing, and grow it.
+image: /images/openapi.png
+url: https://github.com/api-commons/starters
+tags:
+  - OpenAPI
+  - Starter
+  - REST
+
+apis:
+
+  - name: The starter
+    description: OpenAPI 3.1 — copy this file and edit it.
+    properties:
+      - type: OpenAPI
+        url: https://raw.githubusercontent.com/api-commons/starters/main/starter-openapi.yml
+
+  - name: Repository
+    description: Every starter, with a validator that checks them.
+    properties:
+      - type: GitHubRepository
+        url: https://github.com/api-commons/starters
+
+  - name: Specification
+    description: The specification this starter is written against.
+    properties:
+      - type: Specification
+        url: https://spec.openapis.org/oas/latest.html
+---

--- a/assets/rulesets/experience-consistency.spotlight.yaml
+++ b/assets/rulesets/experience-consistency.spotlight.yaml
@@ -3013,10 +3013,10 @@ rules:
     description: 'WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of
       a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly
       implement an error management strategy, with positive impacts for users. This rule inspects the schema returned by an
-      error response and verifies whether it contains the main properties defined in RFC7807: `status`, `title` and `detail`.
+      error response and verifies whether it contains the main properties defined in RFC 9457: `status`, `title` and `detail`.
       An example of a valid payload is ``` { "title": "Not Found", "status": 404, "detail": "Book does not exist; id: 123"
       } ``` See recommendation RAC_REST_NAME_007.'
-    message: Your schema doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
+    message: Your schema doesn't seem to match RFC 9457. Are you sure it is ok? {{path}}
     severity: info
     given: $.paths.[*].responses[?(@property.match(/^(4|5|default)/))][[schema]]
     then:
@@ -3044,8 +3044,8 @@ rules:
       (Response Error Match Problem Schema). Requirement: WARN: This rule is under implementation and just provides an hint.
       Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different
       APIs, enables client to properly implement an error management strategy, with positive impacts for users. This rule
-      inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC7807:
-      `status`, `title` and `detail`. An example of a valid payload is ``` { "title": "Not Found", "status": 404, "detail":
+      inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC
+      9457: `status`, `title` and `detail`. An example of a valid payload is ``` { "title": "Not Found", "status": 404, "detail":
       "Book does not exist; id: 123" } ``` See recommendation RAC_REST_NAME_007. To fix: Adjust the targeted value so it conforms
       to the schema this rule requires. This rule is evaluated at the JSONPath `$.paths.[*].responses[?(@property.match(/^(4|5|default)/))][[schema]]`
       — inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies
@@ -3056,14 +3056,14 @@ rules:
     reference: https://spotlight-rules.com/spec/rules/openapi/response-error-schema-problem-property-names/
     description: 'WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of
       a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly
-      implement an error management strategy, with positive impacts for users. Errors should return RFC7807 objects. Instead,
+      implement an error management strategy, with positive impacts for users. Errors should return RFC 9457 objects. Instead,
       this schema seems to use non standard properties such as: `message`, `msg` and `code`. An error of the following form
-      ``` { "msg": "Book with id: 123 does not exist.", "code": 6063 } ``` can be expressed in RFC7807 with ``` { "detail":
+      ``` { "msg": "Book with id: 123 does not exist.", "code": 6063 } ``` can be expressed in RFC 9457 with ``` { "detail":
       "Book with id: 123 does not exist.", "type": "https://api.example/v1/errors/6063", "status": 404, "title": "Not Found"
       } ``` Returning an URI in `type`, instead of an opaque `code` can help the client in better identifying the error; moreover
       the URI though it should not be dereferenced automatically, can return an actual resource providing guidance in addressing
       the issue. See recommendation RAC_REST_NAME_007.'
-    message: Error response doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
+    message: Error response doesn't seem to match RFC 9457. Are you sure it is ok? {{path}}
     severity: info
     given: $.[responses][?(@property.match(/^(4|5|default)/))][[schema]][properties].*~
     then:
@@ -3083,9 +3083,9 @@ rules:
       (Response Error Schema Problem Property Names). Requirement: WARN: This rule is under implementation and just provides
       an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between
       different APIs, enables client to properly implement an error management strategy, with positive impacts for users.
-      Errors should return RFC7807 objects. Instead, this schema seems to use non standard properties such as: `message`,
+      Errors should return RFC 9457 objects. Instead, this schema seems to use non standard properties such as: `message`,
       `msg` and `code`. An error of the following form ``` { "msg": "Book with id: 123 does not exist.", "code": 6063 } ```
-      can be expressed in RFC7807 with ``` { "detail": "Book with id: 123 does not exist.", "type": "https://api.example/v1/errors/6063",
+      can be expressed in RFC 9457 with ``` { "detail": "Book with id: 123 does not exist.", "type": "https://api.example/v1/errors/6063",
       "status": 404, "title": "Not Found" } ``` Returning an URI in `type`, instead of an opaque `code` can help the client
       in better identifying the error; moreover the URI though it should not be dereferenced automatically, can return an
       actual resource providing guidance in addressing the issue. See recommendation RAC_REST_NAME_007. To fix: Ensure `@key`
@@ -3118,7 +3118,8 @@ rules:
   openapi-response-error-use-problem-json:
     title: Response Error Use Problem JSON
     reference: https://spotlight-rules.com/spec/rules/openapi/response-error-use-problem-json/
-    description: All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 7807).
+    description: All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 9457, which obsoleted
+      RFC 7807).
     message: 'Error response documents MUST use the application/problem+json media type: {{error}}'
     severity: info
     given: $.paths..responses[?( @property >= 400 && @property < 600)].content[*]~
@@ -3138,19 +3139,19 @@ rules:
     - experience:error-handling
     prompt: 'You are editing an OpenAPI document to satisfy the Spotlight API governance rule ''response-error-use-problem-json''
       (Response Error Use Problem JSON). Requirement: All 4xx and 5xx error responses MUST use the `application/problem+json`
-      media type (RFC 7807). To fix: Set the targeted value to one of the allowed values: application/problem+json. This rule
-      is evaluated at the JSONPath `$.paths..responses[?( @property >= 400 && @property < 600)].content[*]~` — inspect every
-      location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave
-      all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only
-      the complete corrected document, with no commentary.'
+      media type (RFC 9457, which obsoleted RFC 7807). To fix: Set the targeted value to one of the allowed values: application/problem+json.
+      This rule is evaluated at the JSONPath `$.paths..responses[?( @property >= 400 && @property < 600)].content[*]~` — inspect
+      every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule,
+      leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return
+      only the complete corrected document, with no commentary.'
   openapi-response-error-use-problem-type:
     title: Response Error Use Problem Type
     reference: https://spotlight-rules.com/spec/rules/openapi/response-error-use-problem-type/
     description: 'Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors
       between different APIs, enables client to properly implement an error management strategy, with positive impacts for
-      users. Error responses should return one of the media-type defined in RFC7807: - `application/problem+json` - `application/problem+xml`
+      users. Error responses should return one of the media-type defined in RFC 9457: - `application/problem+json` - `application/problem+xml`
       An example of a valid response: ``` responses: "503": content: application/problem+json: schema: ... ```.'
-    message: Error responses should support RFC7807 in {{path}}.
+    message: Error responses should support RFC 9457 in {{path}}.
     severity: info
     given: $.paths.[*].responses[?(@property.match(/^(4|5|default)/))].content.*~
     then:
@@ -3171,7 +3172,7 @@ rules:
     prompt: 'You are editing an OpenAPI document to satisfy the Spotlight API governance rule ''response-error-use-problem-type''
       (Response Error Use Problem Type). Requirement: Error management is a key enabler of a resilient API ecosystem. Enforcing
       a consistent schema for errors between different APIs, enables client to properly implement an error management strategy,
-      with positive impacts for users. Error responses should return one of the media-type defined in RFC7807: - `application/problem+json`
+      with positive impacts for users. Error responses should return one of the media-type defined in RFC 9457: - `application/problem+json`
       - `application/problem+xml` An example of a valid response: ``` responses: "503": content: application/problem+json:
       schema: ... ```. To fix: Set the targeted value to one of the allowed values: application/problem+xml, application/problem+json.
       This rule is evaluated at the JSONPath `$.paths.[*].responses[?(@property.match(/^(4|5|default)/))].content.*~` — inspect
@@ -3181,8 +3182,8 @@ rules:
   openapi-response-error-use-problem-type-2:
     title: Response Error Use Problem Type 2
     reference: https://spotlight-rules.com/spec/rules/openapi/response-error-use-problem-type-2/
-    description: Every error response SHOULD support RFC 7807.
-    message: Every error response SHOULD support RFC 7807.
+    description: Every error response SHOULD support RFC 9457.
+    message: Every error response SHOULD support RFC 9457.
     severity: info
     given: $.paths...responses[?(@property.match(/^(4|5)/))].content.*~
     then:
@@ -3199,7 +3200,7 @@ rules:
     - experience:error-handling
     - experience:consistency
     prompt: 'You are editing an OpenAPI document to satisfy the Spotlight API governance rule ''response-error-use-problem-type-2''
-      (Response Error Use Problem Type 2). Requirement: Every error response SHOULD support RFC 7807. To fix: Set the targeted
+      (Response Error Use Problem Type 2). Requirement: Every error response SHOULD support RFC 9457. To fix: Set the targeted
       value to one of the allowed values: application/problem+xml, application/problem+json. This rule is evaluated at the
       JSONPath `$.paths...responses[?(@property.match(/^(4|5)/))].content.*~` — inspect every location it matches and correct
       only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order,

--- a/assets/rulesets/experience-error-handling.spotlight.yaml
+++ b/assets/rulesets/experience-error-handling.spotlight.yaml
@@ -419,10 +419,10 @@ rules:
     description: 'WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of
       a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly
       implement an error management strategy, with positive impacts for users. This rule inspects the schema returned by an
-      error response and verifies whether it contains the main properties defined in RFC7807: `status`, `title` and `detail`.
+      error response and verifies whether it contains the main properties defined in RFC 9457: `status`, `title` and `detail`.
       An example of a valid payload is ``` { "title": "Not Found", "status": 404, "detail": "Book does not exist; id: 123"
       } ``` See recommendation RAC_REST_NAME_007.'
-    message: Your schema doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
+    message: Your schema doesn't seem to match RFC 9457. Are you sure it is ok? {{path}}
     severity: info
     given: $.paths.[*].responses[?(@property.match(/^(4|5|default)/))][[schema]]
     then:
@@ -450,8 +450,8 @@ rules:
       (Response Error Match Problem Schema). Requirement: WARN: This rule is under implementation and just provides an hint.
       Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between different
       APIs, enables client to properly implement an error management strategy, with positive impacts for users. This rule
-      inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC7807:
-      `status`, `title` and `detail`. An example of a valid payload is ``` { "title": "Not Found", "status": 404, "detail":
+      inspects the schema returned by an error response and verifies whether it contains the main properties defined in RFC
+      9457: `status`, `title` and `detail`. An example of a valid payload is ``` { "title": "Not Found", "status": 404, "detail":
       "Book does not exist; id: 123" } ``` See recommendation RAC_REST_NAME_007. To fix: Adjust the targeted value so it conforms
       to the schema this rule requires. This rule is evaluated at the JSONPath `$.paths.[*].responses[?(@property.match(/^(4|5|default)/))][[schema]]`
       — inspect every location it matches and correct only what violates the rule. Make the smallest change that satisfies
@@ -483,14 +483,14 @@ rules:
     reference: https://spotlight-rules.com/spec/rules/openapi/response-error-schema-problem-property-names/
     description: 'WARN: This rule is under implementation and just provides an hint. Error management is a key enabler of
       a resilient API ecosystem. Enforcing a consistent schema for errors between different APIs, enables client to properly
-      implement an error management strategy, with positive impacts for users. Errors should return RFC7807 objects. Instead,
+      implement an error management strategy, with positive impacts for users. Errors should return RFC 9457 objects. Instead,
       this schema seems to use non standard properties such as: `message`, `msg` and `code`. An error of the following form
-      ``` { "msg": "Book with id: 123 does not exist.", "code": 6063 } ``` can be expressed in RFC7807 with ``` { "detail":
+      ``` { "msg": "Book with id: 123 does not exist.", "code": 6063 } ``` can be expressed in RFC 9457 with ``` { "detail":
       "Book with id: 123 does not exist.", "type": "https://api.example/v1/errors/6063", "status": 404, "title": "Not Found"
       } ``` Returning an URI in `type`, instead of an opaque `code` can help the client in better identifying the error; moreover
       the URI though it should not be dereferenced automatically, can return an actual resource providing guidance in addressing
       the issue. See recommendation RAC_REST_NAME_007.'
-    message: Error response doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
+    message: Error response doesn't seem to match RFC 9457. Are you sure it is ok? {{path}}
     severity: info
     given: $.[responses][?(@property.match(/^(4|5|default)/))][[schema]][properties].*~
     then:
@@ -510,9 +510,9 @@ rules:
       (Response Error Schema Problem Property Names). Requirement: WARN: This rule is under implementation and just provides
       an hint. Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors between
       different APIs, enables client to properly implement an error management strategy, with positive impacts for users.
-      Errors should return RFC7807 objects. Instead, this schema seems to use non standard properties such as: `message`,
+      Errors should return RFC 9457 objects. Instead, this schema seems to use non standard properties such as: `message`,
       `msg` and `code`. An error of the following form ``` { "msg": "Book with id: 123 does not exist.", "code": 6063 } ```
-      can be expressed in RFC7807 with ``` { "detail": "Book with id: 123 does not exist.", "type": "https://api.example/v1/errors/6063",
+      can be expressed in RFC 9457 with ``` { "detail": "Book with id: 123 does not exist.", "type": "https://api.example/v1/errors/6063",
       "status": 404, "title": "Not Found" } ``` Returning an URI in `type`, instead of an opaque `code` can help the client
       in better identifying the error; moreover the URI though it should not be dereferenced automatically, can return an
       actual resource providing guidance in addressing the issue. See recommendation RAC_REST_NAME_007. To fix: Ensure `@key`
@@ -545,7 +545,8 @@ rules:
   openapi-response-error-use-problem-json:
     title: Response Error Use Problem JSON
     reference: https://spotlight-rules.com/spec/rules/openapi/response-error-use-problem-json/
-    description: All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 7807).
+    description: All 4xx and 5xx error responses MUST use the `application/problem+json` media type (RFC 9457, which obsoleted
+      RFC 7807).
     message: 'Error response documents MUST use the application/problem+json media type: {{error}}'
     severity: info
     given: $.paths..responses[?( @property >= 400 && @property < 600)].content[*]~
@@ -565,19 +566,19 @@ rules:
     - experience:error-handling
     prompt: 'You are editing an OpenAPI document to satisfy the Spotlight API governance rule ''response-error-use-problem-json''
       (Response Error Use Problem JSON). Requirement: All 4xx and 5xx error responses MUST use the `application/problem+json`
-      media type (RFC 7807). To fix: Set the targeted value to one of the allowed values: application/problem+json. This rule
-      is evaluated at the JSONPath `$.paths..responses[?( @property >= 400 && @property < 600)].content[*]~` — inspect every
-      location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule, leave
-      all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return only
-      the complete corrected document, with no commentary.'
+      media type (RFC 9457, which obsoleted RFC 7807). To fix: Set the targeted value to one of the allowed values: application/problem+json.
+      This rule is evaluated at the JSONPath `$.paths..responses[?( @property >= 400 && @property < 600)].content[*]~` — inspect
+      every location it matches and correct only what violates the rule. Make the smallest change that satisfies the rule,
+      leave all unrelated content, key order, comments, and formatting unchanged, and keep the document valid OpenAPI. Return
+      only the complete corrected document, with no commentary.'
   openapi-response-error-use-problem-type:
     title: Response Error Use Problem Type
     reference: https://spotlight-rules.com/spec/rules/openapi/response-error-use-problem-type/
     description: 'Error management is a key enabler of a resilient API ecosystem. Enforcing a consistent schema for errors
       between different APIs, enables client to properly implement an error management strategy, with positive impacts for
-      users. Error responses should return one of the media-type defined in RFC7807: - `application/problem+json` - `application/problem+xml`
+      users. Error responses should return one of the media-type defined in RFC 9457: - `application/problem+json` - `application/problem+xml`
       An example of a valid response: ``` responses: "503": content: application/problem+json: schema: ... ```.'
-    message: Error responses should support RFC7807 in {{path}}.
+    message: Error responses should support RFC 9457 in {{path}}.
     severity: info
     given: $.paths.[*].responses[?(@property.match(/^(4|5|default)/))].content.*~
     then:
@@ -598,7 +599,7 @@ rules:
     prompt: 'You are editing an OpenAPI document to satisfy the Spotlight API governance rule ''response-error-use-problem-type''
       (Response Error Use Problem Type). Requirement: Error management is a key enabler of a resilient API ecosystem. Enforcing
       a consistent schema for errors between different APIs, enables client to properly implement an error management strategy,
-      with positive impacts for users. Error responses should return one of the media-type defined in RFC7807: - `application/problem+json`
+      with positive impacts for users. Error responses should return one of the media-type defined in RFC 9457: - `application/problem+json`
       - `application/problem+xml` An example of a valid response: ``` responses: "503": content: application/problem+json:
       schema: ... ```. To fix: Set the targeted value to one of the allowed values: application/problem+xml, application/problem+json.
       This rule is evaluated at the JSONPath `$.paths.[*].responses[?(@property.match(/^(4|5|default)/))].content.*~` — inspect
@@ -608,8 +609,8 @@ rules:
   openapi-response-error-use-problem-type-2:
     title: Response Error Use Problem Type 2
     reference: https://spotlight-rules.com/spec/rules/openapi/response-error-use-problem-type-2/
-    description: Every error response SHOULD support RFC 7807.
-    message: Every error response SHOULD support RFC 7807.
+    description: Every error response SHOULD support RFC 9457.
+    message: Every error response SHOULD support RFC 9457.
     severity: info
     given: $.paths...responses[?(@property.match(/^(4|5)/))].content.*~
     then:
@@ -626,7 +627,7 @@ rules:
     - experience:error-handling
     - experience:consistency
     prompt: 'You are editing an OpenAPI document to satisfy the Spotlight API governance rule ''response-error-use-problem-type-2''
-      (Response Error Use Problem Type 2). Requirement: Every error response SHOULD support RFC 7807. To fix: Set the targeted
+      (Response Error Use Problem Type 2). Requirement: Every error response SHOULD support RFC 9457. To fix: Set the targeted
       value to one of the allowed values: application/problem+xml, application/problem+json. This rule is evaluated at the
       JSONPath `$.paths...responses[?(@property.match(/^(4|5)/))].content.*~` — inspect every location it matches and correct
       only what violates the rule. Make the smallest change that satisfies the rule, leave all unrelated content, key order,

--- a/rules/index.html
+++ b/rules/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Rules
-description: The Spotlight rule catalog — 733 openly-governed API governance rules across 12 artifact types (OpenAPI, AsyncAPI, Arazzo, JSON Schema, APIs.json, MCP, and more). Each rule is a single testable assertion you can run with the Spotlight CLI, the browser validator, the HTTP API, an MCP server, or in CI.
+description: The Spotlight rule catalog — 740 openly-governed API governance rules across 12 artifact types (OpenAPI, AsyncAPI, Arazzo, JSON Schema, APIs.json, MCP, and more). Each rule is a single testable assertion you can run with the Spotlight CLI, the browser validator, the HTTP API, an MCP server, or in CI.
 ---
 
 {% assign cat = site.data.spotlight_rules %}

--- a/scripts/generate-spotlight.py
+++ b/scripts/generate-spotlight.py
@@ -17,6 +17,22 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent          # api-commons/
 SRC = ROOT.parent / "spotlight-validator" / "rules" / "all-rules.yaml"
 FN_SRC = ROOT.parent / "spotlight-validator" / "src" / "functions"
+
+# The rule catalog lives in a SIBLING checkout, not in this repo. Check for it
+# up front and say so plainly — the original remote for spotlight-validator was
+# lost once, and a run against a missing or stale checkout silently regenerates
+# _data/spotlight_rules.json from whatever happens to be on disk. That is how
+# corrected content (e.g. the RFC 7807 -> RFC 9457 pass) gets quietly reverted.
+if not SRC.exists():
+    raise SystemExit(
+        f"Rule catalog not found: {SRC}\n\n"
+        "This script reads the Spotlight rule catalog from a sibling checkout.\n"
+        "Clone it next to this repo, then re-run:\n\n"
+        "    git clone https://github.com/api-commons/spotlight-validator.git "
+        f"{ROOT.parent / 'spotlight-validator'}\n\n"
+        "The repo is PRIVATE. Do not hand-edit _data/spotlight_rules.json as a\n"
+        "workaround — it is generated, and the next run overwrites it."
+    )
 SITE = "https://spotlight-rules.com"
 DOC = SITE + "/spec/"
 

--- a/starters/index.html
+++ b/starters/index.html
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Starters
+description: The smallest correct version of each artifact in the API Commons stack — a starter OpenAPI, APIs.json and JSON Schema you copy and grow. Each one lints clean, so whatever you build on top starts from zero findings.
+---
+
+<h2>Starters</h2>
+
+<p>The <strong>smallest correct version</strong> of each artifact in the API Commons stack. Copy one, rename everything, and grow it.</p>
+
+<p>A <strong>starter</strong> is the smallest document that is still correct and worth copying. A <a href="/base/"><strong>base</strong></a> is a full working template for a real domain — the whole error contract, pagination, conditional writes, merge-patch. Start here when you are starting something; start from a base when one already resembles what you are building.</p>
+
+<p>The starter OpenAPI returns <strong>zero findings</strong> under both <code>spectral:oas</code> and the <a href="https://github.com/api-commons/spectral-problem-details-ruleset">API Commons Problem Details ruleset</a>. That is deliberate — whatever you build on top of it starts from zero, so the first warning you ever see is one you introduced. A starter that ships with warnings teaches you to ignore warnings.</p>
+
+<table width="100%">
+{% for property in site.starters %}
+	<tr>
+		<td align="center">
+			<a href="{{ property.url }}"><img src="{{ property.image }}" width="100" style="margin: 15px;" /></a>
+		</td>
+		<td valign="top" style="padding: 30px">
+			<strong>{{ property.name }}</strong> - {{ property.description }}
+		</td>
+		<td width="10%" align="center">
+			<a href="{{ property.url }}">
+				<button type="button" class="btn btn-dark">More Info</button>
+			</a>
+		</td>
+	</tr>
+{% endfor %}
+</table>
+
+<p class="text-center"><a href="https://github.com/api-commons/starters"><strong>Every starter on GitHub</strong></a></p>
+<br>


### PR DESCRIPTION
#32 merged while this was in flight, so the rest of #9 lands here. **Builds on the layout fix that shipped in #32** — without it these base pages would not render.

## Reuse across the base APIs

`accounts`, `images` and `videos` were description-and-tags stubs with **no OpenAPI and no repo**. All three now exist:

| Repo | Covers |
| --- | --- |
| [api-commons/accounts](https://github.com/api-commons/accounts) | list, create, read, merge-patch, close |
| [api-commons/images](https://github.com/api-commons/images) | upload, metadata, renditions, deletion |
| [api-commons/videos](https://github.com/api-commons/videos) | upload, transcoding, renditions, captions, webhooks |

Each ships an OpenAPI 3.1, an APIs.json index, a README, and Apache-2.0.

**The RFC 9457 error components are byte-identical across all three**, composed from one shared block rather than written three times. Adopt more than one base and your clients parse a single error format. That is the reuse the issue asked for.

All three lint **clean** under the ruleset, and under `spectral:oas` apart from `oas3-api-servers` — deliberate, since a base template has no server and a placeholder would only trip `oas3-server-not-example.com`. Building them surfaced three real defects, now fixed: two operations missing descriptions, and a `Conflict` response in images that no operation could return.

Design choices carried into the bases rather than left implicit: merge-patch with the **null-means-delete** trap documented on the patch schema; conditional writes via ETag/If-Match/412; two-step upload so a failed upload doesn't lose metadata; renditions requested rather than enumerated; `alt` on images and captions as a first-class sub-resource on videos; webhooks on videos, because video isn't ready when the upload finishes.

## RFC 7807 → RFC 9457

The catalog cited an RFC obsoleted in July 2023 **22 times, with zero references to its replacement.**

Fixed at the **source** — `spotlight-validator/rules/all-rules.yaml` and `rules/spotlight-recommended.yaml` — then regenerated with `scripts/generate-spotlight.py`, since `_data/spotlight_rules.json` is generated and a direct edit would be overwritten on the next build.

**`rules/sources/*` was deliberately not touched.** Those are harvested third-party rulesets (team-digitale and others). Rewriting them would misrepresent what those vendors actually publish.

Three 7807 mentions remain on purpose, in the phrasing *"RFC 9457, which obsoleted RFC 7807"* — history, not a stale citation.

Also: `rules/index.html` advertised **733** rules; the committed data has held **740** since the agentic-access rules landed.

## Site

- `_base/problem-details-for-http-apis.md` — `url` moves to RFC 9457, and a Spectral Ruleset entry joins the others
- `_base/accounts|images|videos.md` — rebuilt from stubs, each pointing at its OpenAPI, APIs.json, repo, and the ruleset
- `_common/error-codes.md` — three `problem-details` rules under `governance_rules`, ruleset and base under `tools`
- `README` — the ruleset in the tools table, the three bases in the specs list

**One layout fix, needed for any of it to render.** `_layouts/base.html` rendered *only* `GitHubGist` and `GitHubRepository`, giving every repo the hard-coded text "Visit this Base on GitHub". The ruleset would have shown up as a second one, and `OpenAPI`/`APIsJSON` properties would have been dropped silently. Replaced with a `Resources` list. Same class of trap as the `_common` layout: **the layout renders a fixed set, so new frontmatter is invisible until the layout learns it.**

## ~~One caveat to hand on~~ — RESOLVED, see below

**`spotlight-validator` has no live remote** — its origin is recorded as `origin-defunct`. The source-side RFC fix exists only in the local checkout. The generated output is committed here, but **the next person to regenerate from a fresh clone will reintroduce the 7807 text** unless that repo gets a home.

## Related

- [problem-details-for-http-apis#1](https://github.com/api-commons/problem-details-for-http-apis/pull/1) — still open. Brings the base to conformance, and **flags one thing for you:** `info.license` says CC BY-NC-SA 4.0 while the repo LICENSE is Apache-2.0.
- [ruleset-commons#1](https://github.com/api-commons/ruleset-commons/pull/1) — still open. Registers the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added since this PR opened

### spotlight-validator has a home again

The caveat above is resolved. `api-commons/spotlight-validator` **404'd with no rename redirect** — the local checkout was the only copy of the 740-rule catalog behind `/rules/` and `/rulesets/`.

Restored to [api-commons/spotlight-validator](https://github.com/api-commons/spotlight-validator), **private**. All 60 commits plus the RFC pass are pushed. Private rather than public on purpose: the repo was removed from the org at some point, so republishing is a decision to take deliberately, not a side effect of restoring a backup. Flip it if you want. Scanned before pushing — no credentials in the working tree or across the history.

`generate-spotlight.py` now checks for the sibling checkout up front and exits with instructions, instead of throwing a `FileNotFoundError` deep in the run. That silent path is exactly how a corrected catalog gets reverted. The README records the dependency and that the generated files must not be hand-edited.

### Starters

Closes #13. Closes #14.

New repo: **[api-commons/starters](https://github.com/api-commons/starters)**, surfaced here as a `/starters/` collection alongside `/base/`.

| Starter | Spec |
| --- | --- |
| Starter OpenAPI | OpenAPI 3.1 — one resource, RFC 9457 errors |
| Starter APIs.json | APIs.json 0.22 — one index, one API |
| Starter JSON Schema | JSON Schema 2020-12 |

**On #13:** it's titled "Starter OpenAPI" but its body is an APIs.json document. Rather than guess which half was the mistake, **both ship** — they're different layers and both were missing. The body was `specificationVersion: 0.18`; this is written against **0.22**, the current schema.

**Starter is not base**, and the section says so. A starter is the smallest document still correct and worth copying; a base is a full working template for a real domain. The two link to each other.

**The starter OpenAPI returns zero findings** under both `spectral:oas` and the Problem Details ruleset. Deliberate — whatever you build on it starts from zero, so the first warning you see is one you introduced. Writing it caught two defects in my own first draft: 401 and 429 were sharing a generic problem response, so neither carried the header its status code requires.

`validate.py` checks more than well-formedness, with no Node dependency: the JSON Schema starter's own `examples` are validated against the properties they sit on; the APIs.json starter validates against the schema **fetched live** from `apis-json/api-json` rather than a vendored copy that would drift; and the OpenAPI starter's `Problem` schema is checked against RFC 9457 member types.

Site plumbing: a `starters` collection in `_config.yml` and a `starters` layout derived from the base layout. Verified the other six collections still build and the base pages are unaffected.
