### PR TITLE
Standardize README — API Commons footer and license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,19 @@ New here? Start with the hub, then dig into the tools or the building blocks.
 A project of [API Evangelist](https://apievangelist.com), maintained openly under
 API Commons. The building blocks and tools are open and free to use; API Evangelist
 offers expert API governance and strategy services around them.
+
+## Part of API Commons
+
+A browser-first tool from **[API Commons](https://apicommons.org)** — everything runs locally in your browser, so your tokens and data never leave it. See every tool at **[apicommons.org/tools](https://apicommons.org/tools/)** and the machine-readable building blocks at **[apicommons.org](https://apicommons.org)**.
+
+**Related tools**
+- [API Validator](https://validator.apicommons.org) — governance linting for OpenAPI, AsyncAPI, Arazzo and JSON Schema
+- [Ruleset Commons](https://rulesets.apicommons.org) — a registry of adoptable, provenanced rulesets
+- [Spectral Ruleset Studio](https://studio.apicommons.org) — turn a prose style guide into an owned ruleset
+
+## License
+
+**[Apache-2.0](LICENSE).**
+
+API Commons licenses **code** under Apache-2.0 and **artifacts** — schemas, rulesets,
+examples and API descriptions — under CC BY-NC-SA 4.0.


### PR DESCRIPTION
Standardizes this README against the rest of the org.

- Adds the **Part of API Commons** footer, linking the hub and related work.
- Adds a **License** section stating how this repo is licensed.

Nothing existing was rewritten — this only appends what was missing.

Part of an org-wide standardization pass: every repo gets a resolving homepage, the `api-commons` topic, a description, the footer, and a license section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)